### PR TITLE
Optimize regular expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 var escapeStringRegexp = require('escape-string-regexp');
 
 module.exports = function (str, match) {
-	var regex = new RegExp('^' + escapeStringRegexp(match) + '[^]*$');
+	var regex = new RegExp('^' + escapeStringRegexp(match));
 	return regex.test(str);
 };


### PR DESCRIPTION
Matching the end of the string forces the regular expression to iterate through the entire content, which can be an issue for very large strings. This change simplifies the regular expression to match only the beginning of the target string.
